### PR TITLE
OperationOutcome as Error if returned by the FHIR service

### DIFF
--- a/client.go
+++ b/client.go
@@ -189,7 +189,6 @@ func (d BaseClient) doRequest(httpRequest *http.Request, target any, opts ...Opt
 		if d.config.Non2xxStatusHandler != nil {
 			d.config.Non2xxStatusHandler(httpResponse, data)
 		}
-		// Checking for OperationOutcome
 		if err = checkForOperationOutcome(data); err != nil {
 			return err
 		}
@@ -198,7 +197,6 @@ func (d BaseClient) doRequest(httpRequest *http.Request, target any, opts ...Opt
 	if len(data) > d.config.MaxResponseSize {
 		return fmt.Errorf("FHIR response exceeds max. safety limit of %d bytes (%s %s, status=%d)", d.config.MaxResponseSize, httpRequest.Method, httpRequest.URL.String(), httpResponse.StatusCode)
 	}
-	// Checking for OperationOutcome
 	if err = checkForOperationOutcome(data); err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/SanteonNL/go-fhir-client
 go 1.22.2
 
 require (
+	github.com/samply/golang-fhir-models/fhir-models v0.3.2
 	github.com/stretchr/testify v1.9.0
 	go.uber.org/mock v0.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/samply/golang-fhir-models/fhir-models v0.3.2 h1:rdMFT5so500jqpDzWJ0bpOeIjqIWcK+czbbG/1RxgFk=
+github.com/samply/golang-fhir-models/fhir-models v0.3.2/go.mod h1:6Yqror2rP2Hyxa2+MQLvvVzH4g6/fXoHUCVdI95VhTc=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 go.uber.org/mock v0.4.0 h1:VcM4ZOtdbR4f6VXfiOpwpVJDL6lCReaZ6mw31wqh7KU=

--- a/operation_outcome.go
+++ b/operation_outcome.go
@@ -1,0 +1,31 @@
+package fhirclient
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/samply/golang-fhir-models/fhir-models/fhir"
+)
+
+type OperationOutcome struct {
+	fhir.OperationOutcome
+	ResourceType *string `bson:"resourceType" json:"resourceType"`
+}
+
+func (r OperationOutcome) IsOperationOutcome() bool {
+	if r.ResourceType == nil {
+		return false
+	}
+
+	return strings.EqualFold(*r.ResourceType, "OperationOutcome")
+}
+
+func (r OperationOutcome) Error() string {
+	var messages []string
+	for _, issue := range r.Issue {
+		if issue.Diagnostics != nil {
+			messages = append(messages, fmt.Sprintf("[%v %v] %s", issue.Code, issue.Severity, *issue.Diagnostics))
+		}
+	}
+	return fmt.Sprintf("OperationOutcome, issues: %s", strings.Join(messages, "; "))
+}

--- a/operation_outcome.go
+++ b/operation_outcome.go
@@ -1,11 +1,32 @@
 package fhirclient
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
 	"github.com/samply/golang-fhir-models/fhir-models/fhir"
 )
+
+// Check if the data contains an OperationalOutcome with an error in the issues.
+// If `errorEvenWithoutIssue` is set `true`, we don't check the issues and instead
+// always assume an OperationalOutcome is an error.
+func checkForOperationOutcomeError(data []byte, errorEvenWithoutIssue bool) error {
+	var ooc OperationOutcome
+
+	if err := json.Unmarshal(data, &ooc); err != nil {
+		// We're only checking for an OperationOutcome, not for malformed JSON.
+		return nil
+	}
+
+	if ooc.IsOperationOutcome() {
+		if errorEvenWithoutIssue || ooc.ContainsError() {
+			return ooc
+		}
+	}
+
+	return nil
+}
 
 type OperationOutcome struct {
 	fhir.OperationOutcome
@@ -20,10 +41,22 @@ func (r OperationOutcome) IsOperationOutcome() bool {
 	return strings.EqualFold(*r.ResourceType, "OperationOutcome")
 }
 
+func (r OperationOutcome) ContainsError() bool {
+	for _, issue := range r.Issue {
+		if issue.Severity == fhir.IssueSeverityFatal || issue.Severity == fhir.IssueSeverityError {
+			return true
+		}
+	}
+
+	return false
+}
+
 func (r OperationOutcome) Error() string {
 	var messages []string
 	for _, issue := range r.Issue {
-		if issue.Diagnostics != nil {
+		if issue.Diagnostics == nil {
+			messages = append(messages, fmt.Sprintf("[%v %v]", issue.Code, issue.Severity))
+		} else {
 			messages = append(messages, fmt.Sprintf("[%v %v] %s", issue.Code, issue.Severity, *issue.Diagnostics))
 		}
 	}

--- a/operation_outcome_test.go
+++ b/operation_outcome_test.go
@@ -1,0 +1,105 @@
+package fhirclient_test
+
+import (
+	"testing"
+
+	fhirclient "github.com/SanteonNL/go-fhir-client"
+	"github.com/samply/golang-fhir-models/fhir-models/fhir"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOperationOutcome_IsOperationOutcome(t *testing.T) {
+	t.Run("ResourceType: nil", func(t *testing.T) {
+		ooc := fhirclient.OperationOutcome{
+			OperationOutcome: fhir.OperationOutcome{},
+			ResourceType:     nil,
+		}
+		assert.False(t, ooc.IsOperationOutcome())
+	})
+	t.Run("ResourceType: FooBar", func(t *testing.T) {
+		rt := "FooBar"
+		ooc := fhirclient.OperationOutcome{
+			OperationOutcome: fhir.OperationOutcome{},
+			ResourceType:     &rt,
+		}
+		assert.False(t, ooc.IsOperationOutcome())
+	})
+	t.Run("ResourceType: OperationOutcome", func(t *testing.T) {
+		rt := "OperationOutcome"
+		ooc := fhirclient.OperationOutcome{
+			OperationOutcome: fhir.OperationOutcome{},
+			ResourceType:     &rt,
+		}
+		assert.True(t, ooc.IsOperationOutcome())
+	})
+}
+
+func TestOperationOutcome_Error(t *testing.T) {
+	rt := "OperationOutcome"
+
+	t.Run("Issue: nil", func(t *testing.T) {
+		ooc := fhirclient.OperationOutcome{
+			OperationOutcome: fhir.OperationOutcome{},
+			ResourceType:     &rt,
+		}
+		assert.Equal(t, "OperationOutcome, issues: ", ooc.Error())
+	})
+
+	t.Run("Diagnostics: nil", func(t *testing.T) {
+		ooc := fhirclient.OperationOutcome{
+			OperationOutcome: fhir.OperationOutcome{
+				Issue: []fhir.OperationOutcomeIssue{
+					{
+						Code:        fhir.IssueTypeProcessing,
+						Severity:    fhir.IssueSeverityError,
+						Diagnostics: nil,
+					},
+				},
+			},
+			ResourceType: &rt,
+		}
+		assert.Equal(t, "OperationOutcome, issues: ", ooc.Error())
+	})
+
+	t.Run("Diagnostics: some error message", func(t *testing.T) {
+		d := "some error message"
+
+		ooc := fhirclient.OperationOutcome{
+			OperationOutcome: fhir.OperationOutcome{
+				Issue: []fhir.OperationOutcomeIssue{
+					{
+						Code:        fhir.IssueTypeProcessing,
+						Severity:    fhir.IssueSeverityError,
+						Diagnostics: &d,
+					},
+				},
+			},
+			ResourceType: &rt,
+		}
+		assert.Equal(t, "OperationOutcome, issues: [processing error] some error message", ooc.Error())
+	})
+
+	t.Run("Multiple issues", func(t *testing.T) {
+		de := "some error message"
+		dw := "some warning message"
+
+		ooc := fhirclient.OperationOutcome{
+			OperationOutcome: fhir.OperationOutcome{
+				Issue: []fhir.OperationOutcomeIssue{
+					{
+						Code:        fhir.IssueTypeProcessing,
+						Severity:    fhir.IssueSeverityError,
+						Diagnostics: &de,
+					},
+					{
+						Code:        fhir.IssueTypeUnknown,
+						Severity:    fhir.IssueSeverityWarning,
+						Diagnostics: &dw,
+					},
+				},
+			},
+			ResourceType: &rt,
+		}
+		assert.Equal(t, "OperationOutcome, issues: [processing error] some error message; [unknown warning] some warning message", ooc.Error())
+	})
+}


### PR DESCRIPTION
[INT-255: Parse OperationOutcome on the client side](https://linear.app/zorg-bij-jou/issue/INT-255/orca-or-return-operationoutcome-on-error-and-parse-them-client-side)