### PR TITLE
FIX: Set rather than Add Content-Type header for Search

### DIFF
--- a/client.go
+++ b/client.go
@@ -132,7 +132,7 @@ func (d BaseClient) SearchWithContext(ctx context.Context, resourceType string, 
 	if err != nil {
 		return err
 	}
-	httpRequest.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	httpRequest.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	return d.doRequest(httpRequest, target, opts...)
 }
 


### PR DESCRIPTION
The request coming from the frontend already had the content-type set, so by the time it reached the backend it had duplicate header values and this was causing the search to fail. Since Content-Type should only have one value, we can just set it here