### PR TITLE
FIX: RequestHeaders PreRequestOption only adds missing header values

### DIFF
--- a/client.go
+++ b/client.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"slices"
 	"strings"
 	"time"
 )
@@ -294,21 +295,13 @@ func QueryParam(key, value string) PreRequestOption {
 	}
 }
 
-// RequestHeaders sets the given HTTP headers on the request.
+// RequestHeaders sets the given HTTP headers on the request. Values are only added if they are not already present, this prevents duplicates
 func RequestHeaders(headers http.Header) PreRequestOption {
 	return func(_ Client, r *http.Request) {
 		for k, v := range headers {
-			// Make sure to copy the headers, but don't duplicate existing values
 			existing := r.Header[k]
 			for _, newValue := range v {
-				alreadyPresent := false
-				for _, existingValue := range existing {
-					if existingValue == newValue {
-						alreadyPresent = true
-						break
-					}
-				}
-				if !alreadyPresent {
+				if !slices.Contains(existing, newValue) {
 					r.Header.Add(k, newValue)
 				}
 			}

--- a/client.go
+++ b/client.go
@@ -298,8 +298,20 @@ func QueryParam(key, value string) PreRequestOption {
 func RequestHeaders(headers http.Header) PreRequestOption {
 	return func(_ Client, r *http.Request) {
 		for k, v := range headers {
-			// Make sure to copy the headers
-			r.Header[k] = append(r.Header[k], v...)
+			// Make sure to copy the headers, but don't duplicate existing values
+			existing := r.Header[k]
+			for _, newValue := range v {
+				alreadyPresent := false
+				for _, existingValue := range existing {
+					if existingValue == newValue {
+						alreadyPresent = true
+						break
+					}
+				}
+				if !alreadyPresent {
+					r.Header.Add(k, newValue)
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
Ran into an issue where values would be duplicated if added again, for example if the FE set the Content-Type, it would be set again by the PRO. This change ensures that values are only added if they are not already set for a given header key